### PR TITLE
Moving dnssec keygen to ansible task

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,3 +102,4 @@ export TEUTH_VARS=teuthology-foo.yml
 ./deploy-teuthology --cloud ovh --ns --rebuild
 ```
 
+> **NOTE**: Due to **HMAC-MD5** being depricated on Tumbleweed dnssec key generation was temporarily moved from `deploy-teuthology.sh` to `teuthology_nameserver` ansible role and `dnssec_keygen` task

--- a/deploy-teuthology
+++ b/deploy-teuthology
@@ -139,18 +139,6 @@ fi
 
 if $REBUILD || $BUILD ; then
 
-function make_dns_key() {
-    local zone_name=${1:-"nbg.suse.de"}
-    local keys_path=${2:-"$STATE_PATH"}
-    echo "Create dnssec keys for $zone_name" > /dev/stderr
-    # we need to provide full path to dnssec-keygen, otherwise it requires sudo
-    KEY_NAME=$(/usr/sbin/dnssec-keygen -r /dev/urandom -a HMAC-MD5 -b  512 -n HOST $zone_name)
-    #sudo chown $USER: $KEY_NAME*
-    mv $KEY_NAME.* $keys_path
-    echo $KEY_NAME
-}
-
-
 cat > $STATE_PATH/teuthology_server.yml << END
 teuthology_name: $NAME
 teuthology_addr: $private_addr
@@ -173,21 +161,13 @@ fi
 
 if $SETUPNS ; then
 ZONE_DOMAIN=${OS_CLOUD}.suse.de
-DNSKEY_NAME=$(make_dns_key $ZONE_DOMAIN $PWD/secrets)
-PUBKEY_NAME=${DNSKEY_NAME}.key
-PRIKEY_NAME=${DNSKEY_NAME}.private
-ZONE_SECRET=$(cat $PWD/secrets/$PRIKEY_NAME | yj | jq -r .Key)
 cat >> $STATE_PATH/teuthology_server.yml << END
 #keys_dir: $STATE_PATH
 nsupdate_web_server: "$private_addr"
 lab_domain:  $ZONE_DOMAIN
 zone_name:   $ZONE_DOMAIN
 zone_domain: $ZONE_DOMAIN
-zone_secret: $ZONE_SECRET
-pubkey_name: $PUBKEY_NAME
-prikey_name: $PRIKEY_NAME
 END
-scp $sshopts $PWD/secrets/${DNSKEY_NAME}* $LOGIN_USER@$target:
 
 ANSIBLE_CONFIG=teuthology-ansible.cfg \
     ansible-playbook $VERBOSE \

--- a/openstack/userdata-ecp.yaml.orig
+++ b/openstack/userdata-ecp.yaml.orig
@@ -5,6 +5,8 @@
 #    root:CHANGEME
 #  expire: False
 
+disable_root: false
+
 bootcmd:
   - rm /etc/resolv.conf
 runcmd:

--- a/roles/teuthology_nameserver/tasks/dnssec-keygen.yml
+++ b/roles/teuthology_nameserver/tasks/dnssec-keygen.yml
@@ -1,0 +1,26 @@
+#Moved dnssec key generation from deploy-teuthology script to the ansible task due to HMAC-MD5 being deprecated on Tumbleweed.
+- name: Generate new keys
+  shell: "/usr/sbin/dnssec-keygen -r /dev/urandom -a HMAC-MD5 -b  512 -n HOST '{{ zone_name }}'"
+  register:
+    dns_keygen
+
+- name: Get prikey contents
+  slurp:
+    src: "{{ dns_keygen.stdout }}.private"
+  register: prikey_out
+
+- name: Set key vars
+  set_fact:
+    dns_key: "{{ dns_keygen.stdout }}"
+    pubkey_name: "{{ dns_keygen.stdout }}.key"
+    prikey_name: "{{ dns_keygen.stdout }}.private"
+    zone_secret: "{{ (prikey_out.content |  b64decode | from_yaml).Key }}"
+
+- name: Fetch the keys to secrets local path
+  fetch:
+    src: "{{ ansible_env.HOME }}/{{ item }}"
+    dest: "{{ secrets_path }}/"
+    flat: true
+  loop:
+    - "{{ pubkey_name }}"
+    - "{{ prikey_name }}"

--- a/roles/teuthology_nameserver/tasks/main.yml
+++ b/roles/teuthology_nameserver/tasks/main.yml
@@ -3,6 +3,11 @@
   tags:
     - packages
 
+- name: generate dnssec key
+  import_tasks: dnssec-keygen.yml
+  tags:
+    - dnssec-keygen
+
 - name: Enable and start ntpd
   service:
     name: ntpd


### PR DESCRIPTION
Temporarily moving dnssec key generation from deploy-teuthology script to
teuthology_nameserver ansible role due to current encryption algorithm
being depricated in Tumbleweed

Signed-off-by: Georgios Kyratsas <gkyratsas@suse.com>