### PR TITLE
teuthology_nameserver: disable become for local_action

### DIFF
--- a/roles/teuthology_nameserver/tasks/tsig-keygen.yml
+++ b/roles/teuthology_nameserver/tasks/tsig-keygen.yml
@@ -14,6 +14,9 @@
     module: copy 
     content: "{{ tsig_key }}"
     dest: "{{ secrets_path }}/{{ pubkey_name }}"
+  # specifically disable become to avoid sudo on localhost
+  vars:
+    ansible_become: false
 
 - name: Copy tsig key to remote host
   copy:


### PR DESCRIPTION
When it is defined become=true somewhere in playbook
the local_action is trying to use sudo which has no sense
and causes a failure on the ansible client without sudo.

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@suse.com>